### PR TITLE
fix: prevent cycles with broadcast backends

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-log-backend
-version: 0.1.1
+version: 0.2.0
 crystal: ~> 0.36
 license: MIT
 

--- a/src/ext/log/broadcast_backend.cr
+++ b/src/ext/log/broadcast_backend.cr
@@ -1,0 +1,8 @@
+require "log"
+
+class Log::BroadcastBackend < Log::Backend
+  def append(backend : Log::Backend, level : Severity)
+    # Ignore addition of self to set of broadcast backends
+    previous_def unless backend == self
+  end
+end

--- a/src/placeos-log-backend.cr
+++ b/src/placeos-log-backend.cr
@@ -1,6 +1,8 @@
 require "action-controller"
 require "log"
 
+require "./ext/log/broadcast_backend"
+
 module PlaceOS::LogBackend
   STDOUT        = ActionController.default_backend
   LOGSTASH_HOST = ENV["LOGSTASH_HOST"]?.presence
@@ -22,7 +24,7 @@ module PlaceOS::LogBackend
         socket.sync = false
       end
     rescue IO::Error
-      Log.error { {message: "failed to connect to logstash", host: host, port: port} }
+      Log.error { {message: "failed to connect to logstash", host: logstash_host, port: logstash_port} }
       nil
     end
 


### PR DESCRIPTION
- rescue connection errors to logstash
- ignore the addition of self to a broadcast backend, preventing cycles