### PR TITLE
feat: add methods to switch severity at runtime

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-log-backend
-version: 0.3.0
+version: 0.4.0
 crystal: ~> 1
 license: MIT
 

--- a/src/placeos-log-backend.cr
+++ b/src/placeos-log-backend.cr
@@ -4,9 +4,70 @@ require "log"
 require "./ext/log/broadcast_backend"
 
 module PlaceOS::LogBackend
+  Log           = ::Log.for(self)
   STDOUT        = ActionController.default_backend
   LOGSTASH_HOST = ENV["LOGSTASH_HOST"]?.presence
   LOGSTASH_PORT = ENV["LOGSTASH_PORT"]?.try &.to_i?
+
+  # Hook to toggle `Log` instances' `:trace` severity
+  # ## `enabled`
+  # - `true`
+  # `:trace` for _all_ `Log` instances.
+  #
+  # - `false`
+  # returns `namespaces`'s `Log`s to `:info` if `production`
+  # is `true` and otherwise it is set to `:debug`.
+  # `Log`'s that are not registered under `namespaces` are toggled to `default`.
+  #
+  def self.trace_logging(
+    enabled : Bool,
+    production : Bool,
+    namespaces : Array(String),
+    default : ::Log::Severity,
+    backend
+  )
+    production_log_level = production ? default : ::Log::Severity::Debug
+    namespace_log_level = enabled ? ::Log::Severity::Trace : production_log_level
+    default_log_level = enabled ? ::Log::Severity::Trace : default
+
+    ::Log.builder.bind "*", default_log_level, backend
+    Log.info { "default log level changed to #{default_log_level}" }
+
+    namespaces.each do |namespace|
+      ::Log.builder.bind(namespace, namespace_log_level, backend)
+    end
+    Log.info { "#{namespaces.join(", ")} log level changed to #{namespace_log_level}" }
+  end
+
+  # Registers callbacks for USR1 and USR2
+  #
+  # **`USR1`**
+  # turns on `:trace` for _all_ `Log` instances
+  #
+  # **`USR2`**
+  # returns `namespaces`'s `Log`s to `:info` if `production` is `true`,
+  # otherwise it is set to `:debug`.
+  # `Log`'s not registered under `namespaces` are toggled to `default`
+  #
+  # ## Usage
+  # - `$ kill -USR2 ${the_application_pid}`
+  # - `$ kill -USR2 ${the_application_pid}`
+  def self.register_severity_switch_signals(
+    production : Bool,
+    namespaces : Array(String),
+    default : ::Log::Severity = ::Log::Severity::Info,
+    backend = self.log_backend
+  ) : Nil
+    # Allow signals to change the log level at run-time
+    logging = Proc(Signal, Nil).new do |signal|
+      trace_logging(signal.usr1?, production, namespaces, default, backend)
+      # Ignore standard behaviour of the signal
+      signal.ignore
+    end
+
+    Signal::USR1.trap &logging
+    Signal::USR2.trap &logging
+  end
 
   def self.log_backend(
     logstash_host : String? = LOGSTASH_HOST,


### PR DESCRIPTION
Adds...
- `PlaceOS::LogBackend.trace_logging`: Method to toggle in and out of `:trace` severity
- `PlaceOS::LogBackend.register_severity_switch_signals`: Method to register **`USR1`** and **`USR2`** to switch `Log`'s severity 