### PR TITLE
refactor: use `UDP_LOG_HOST` and `UDP_LOG_PORT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # PlaceOS Log Backend
 
 Logging backend in common use across PlaceOS services.
-Will open a UDP stream to a logstash server if `LOGSTASH_HOST` and `LOGSTASH_PORT` are configured.
+
+A UDP stream will be opened to a log server if `UDP_LOG_HOST` and `UDP_LOG_PORT`
+are in the environment.
 
 ## Usage
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-log-backend
-version: 0.4.0
+version: 0.5.0
 crystal: ~> 1
 license: MIT
 


### PR DESCRIPTION
UDP log streams are configured via `UDP_LOG_HOST` and `UDP_LOG_PORT`.

To avoid a breaking change, configuration via `LOGSTASH_HOST` and `LOGSTASH_PORT` is still possible.