### PR TITLE
feat: support for JSON stdout

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-log-backend
-version: 0.5.1
+version: 0.6.0
 crystal: ~> 1
 license: MIT
 


### PR DESCRIPTION
Adds `PLACE_LOG_FORMAT` option, with valid values of `line` or `json`.
The values are parsed as an enum so uppercase forms are valid too.
The default is `line`, which retains the existing formatting.