### PR TITLE
feat: add `PlaceOS::LogBackend.configure_opentelemetry`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,12 +1,14 @@
 name: placeos-log-backend
-version: 0.6.0
-crystal: ~> 1
+version: 0.7.0
+crystal: "~> 1.0"
 license: MIT
 
 dependencies:
   action-controller:
     github: spider-gazelle/action-controller
     version: ~> 4
+  opentelemetry-instrumentation:
+    github: wyhaines/opentelemetry-instrumentation.cr
 
 authors:
   - Caspian Baska <caspian@place.tech>


### PR DESCRIPTION
The client will not initialize if the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable is not present.

## Usage

```
PlaceOS::LogBackend.configure_opentelemetry(
  service_name: APP_NAME,
  service_version: VERSION,
)
```

## Environment

*OTLP configuration*
- `OTEL_EXPORTER_OTLP_ENDPOINT`
- `OTEL_EXPORTER_OTLP_HEADERS`: e.g `Hello=world,Foo=bar`

*Api Keys*
- `OTEL_EXPORTER_OTLP_API_KEY`
- `NEW_RELIC_LICENSE_KEY`
- `ELASTIC_APM_API_KEY`

**Relevant Issues**

- Placeos/Placeos#138