### PR TITLE
feat(telemetry): propagate trace_id in http requests

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-log-backend
-version: 0.7.3
+version: 0.8.0
 crystal: "~> 1.0"
 license: MIT
 
@@ -8,7 +8,8 @@ dependencies:
     github: spider-gazelle/action-controller
     version: ~> 4
   opentelemetry-instrumentation:
-    github: wyhaines/opentelemetry-instrumentation.cr
+    github: place-labs/opentelemetry-instrumentation.cr
+    branch: feat/spider-gazelle/distributed-trace
 
 authors:
   - Caspian Baska <caspian@place.tech>

--- a/src/ext/http/client.cr
+++ b/src/ext/http/client.cr
@@ -1,0 +1,10 @@
+require "http"
+require "opentelemetry-instrumentation"
+
+class HTTP::Client
+  def_around_exec do |request|
+    # Set the `traceparent` header of current request
+    request.headers["traceparent"] = OpenTelemetry.trace.trace_id
+    yield
+  end
+end

--- a/src/placeos-log-backend/telemetry.cr
+++ b/src/placeos-log-backend/telemetry.cr
@@ -1,6 +1,8 @@
 require "opentelemetry-instrumentation"
 require "opentelemetry-instrumentation/src/opentelemetry/instrumentation/**"
 
+require "../ext/http/client"
+
 module PlaceOS::LogBackend
   # OTLP configuration
   OTEL_EXPORTER_OTLP_ENDPOINT = ENV["OTEL_EXPORTER_OTLP_ENDPOINT"]?.presence


### PR DESCRIPTION
This is a step toward enabling Distributed Tracing in our applications.

This is second to when `HTTP::Client` is instrumented in https://github.com/wyhaines/opentelemetry-instrumentation.cr

**Related Issues**

- https://github.com/PlaceOS/PlaceOS/issues/135