### PR TITLE
feat: add OpenTelemetry log backend

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-log-backend
-version: 0.8.13
+version: 0.9.0
 crystal: "~> 1.0"
 license: MIT
 

--- a/src/placeos-log-backend/constants.cr
+++ b/src/placeos-log-backend/constants.cr
@@ -1,0 +1,31 @@
+module PlaceOS
+  # OTLP configuration
+  OTEL_EXPORTER_OTLP_ENDPOINT = ENV["OTEL_EXPORTER_OTLP_ENDPOINT"]?.presence
+  OTEL_EXPORTER_OTLP_HEADERS  = ENV["OTEL_EXPORTER_OTLP_HEADERS"]?.presence
+
+  # Api Keys
+  OTEL_EXPORTER_OTLP_API_KEY = ENV["OTEL_EXPORTER_OTLP_API_KEY"]?.presence
+  NEW_RELIC_LICENSE_KEY      = ENV["NEW_RELIC_LICENSE_KEY"]?.presence
+  ELASTIC_APM_API_KEY        = ENV["ELASTIC_APM_API_KEY"]?.presence
+
+  LOG_FORMAT = ENV["PLACE_LOG_FORMAT"]?.presence.try { |format| Format.parse format } || Format::Line
+
+  UDP_LOG_HOST = self.env_with_deprecation("UDP_LOG_HOST", "LOGSTASH_HOST")
+  UDP_LOG_PORT = self.env_with_deprecation("UDP_LOG_PORT", "LOGSTASH_PORT").try &.to_i?
+
+  # The first argument will be treated as the correct environment variable.
+  # Presence of follwoing vars will produce warnings.
+  protected def self.env_with_deprecation(*args) : String?
+    if correct_env = ENV[args.first]?.presence
+      return correct_env
+    end
+
+    args[1..].each do |env|
+      found = ENV[env]?.presence
+      if found
+        Log.warn { "using deprecated env var #{env}, please use #{args.first}" }
+        return found
+      end
+    end
+  end
+end

--- a/src/placeos-log-backend/telemetry.cr
+++ b/src/placeos-log-backend/telemetry.cr
@@ -1,5 +1,15 @@
 require "opentelemetry-instrumentation"
-require "opentelemetry-instrumentation/src/opentelemetry/instrumentation/**"
+
+# BEGIN OpenTelemetry Autoinstrumentation
+require "opentelemetry-instrumentation/src/opentelemetry/instrumentation/*"
+require "opentelemetry-instrumentation/src/opentelemetry/instrumentation/shards/*"
+require "opentelemetry-instrumentation/src/opentelemetry/instrumentation/frameworks/spider-gazelle"
+# Require everything except the log instrumentation
+require "opentelemetry-instrumentation/src/opentelemetry/instrumentation/crystal/db"
+require "opentelemetry-instrumentation/src/opentelemetry/instrumentation/crystal/http_client"
+require "opentelemetry-instrumentation/src/opentelemetry/instrumentation/crystal/http_server"
+require "opentelemetry-instrumentation/src/opentelemetry/instrumentation/crystal/http_websocket"
+# END OpenTelemetry Autoinstrumentation
 
 require "./constants"
 

--- a/src/placeos-log-backend/telemetry.cr
+++ b/src/placeos-log-backend/telemetry.cr
@@ -1,16 +1,9 @@
 require "opentelemetry-instrumentation"
 require "opentelemetry-instrumentation/src/opentelemetry/instrumentation/**"
 
+require "./constants"
+
 module PlaceOS::LogBackend
-  # OTLP configuration
-  OTEL_EXPORTER_OTLP_ENDPOINT = ENV["OTEL_EXPORTER_OTLP_ENDPOINT"]?.presence
-  OTEL_EXPORTER_OTLP_HEADERS  = ENV["OTEL_EXPORTER_OTLP_HEADERS"]?.presence
-
-  # Api Keys
-  OTEL_EXPORTER_OTLP_API_KEY = ENV["OTEL_EXPORTER_OTLP_API_KEY"]?.presence
-  NEW_RELIC_LICENSE_KEY      = ENV["NEW_RELIC_LICENSE_KEY"]?.presence
-  ELASTIC_APM_API_KEY        = ENV["ELASTIC_APM_API_KEY"]?.presence
-
   # :nodoc:
   module Telemetry
     Log = ::Log.for(self)


### PR DESCRIPTION
Adds a conditionally configured OpenTelemetry log backend.

We're using this as the `opentelemetry-instrumentation` instrumentation of `Log` doesn't work with our extension of `Log` found in https://github.com/spider-gazelle/log_helper